### PR TITLE
Update restic to 0.14.0

### DIFF
--- a/restic.yaml
+++ b/restic.yaml
@@ -11,9 +11,9 @@ build-commands:
 sources:
   - type: file
     only-arches: [x86_64]
-    url: https://github.com/restic/restic/releases/download/v0.12.1/restic_0.12.1_linux_amd64.bz2
-    sha256: 11d6ee35ec73058dae73d31d9cd17fe79661090abeb034ec6e13e3c69a4e7088
+    url: https://github.com/restic/restic/releases/download/v0.14.0/restic_0.14.0_linux_amd64.bz2
+    sha256: c8da7350dc334cd5eaf13b2c9d6e689d51e7377ba1784cc6d65977bd44ee1165
   - type: file
     only-arches: [aarch64]
-    url: https://github.com/restic/restic/releases/download/v0.12.1/restic_0.12.1_linux_arm64.bz2
-    sha256: c7e58365d0b888a60df772e7857ce8a0b53912bbd287582e865e3c5e17db723f
+    url: https://github.com/restic/restic/releases/download/v0.14.0/restic_0.14.0_linux_arm64.bz2
+    sha256: 24c7ca3fe6905b3a493a67237ff081ba9e11abfb27dcb73f18d0a4595926c35d


### PR DESCRIPTION
This updates the included `restic` to the current version. This release of restic now includes compression support, which should be a nice feature to have.