### PR TITLE
Update dependencies

### DIFF
--- a/duplicity.yaml
+++ b/duplicity.yaml
@@ -10,5 +10,5 @@ build-commands:
   --prefix=${FLATPAK_DEST} "duplicity" --no-build-isolation --no-deps
 sources:
 - type: file
-  url: https://files.pythonhosted.org/packages/02/20/c81f899d34c51760605919b4bae0512fd6e0e481ef4e2a77753762ec81e4/duplicity-3.0.5.1.tar.gz
-  sha256: 06775fa3004e42ef30d2b0adcb8e7c808eafd8998f81e43be4c72648dae72b3e
+  url: https://files.pythonhosted.org/packages/7c/5b/ca25e39ace138a15afb0631c6dc1681c3d70b3ebe4edf72e04f5ad768b27/duplicity-3.0.6.3.tar.gz
+  sha256: 56472b3fccadec4ee436df50cf1cd283b77d86227393924c9ebf9d0b55d190f4

--- a/fasteners.yaml
+++ b/fasteners.yaml
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: Michael Terry
----
+
+# Generated with flatpak-pip-generator --yaml --runtime org.gnome.Sdk//master --output fasteners fasteners
 name: python3-fasteners
 buildsystem: simple
 build-commands:
@@ -10,5 +11,5 @@ build-commands:
   --prefix=${FLATPAK_DEST} "fasteners" --no-build-isolation
 sources:
 - type: file
-  url: https://files.pythonhosted.org/packages/61/bf/fd60001b3abc5222d8eaa4a204cd8c0ae78e75adc688f33ce4bf25b7fafa/fasteners-0.19-py3-none-any.whl
-  sha256: 758819cb5d94cdedf4e836988b74de396ceacb8e2794d21f82d131fd9ee77237
+  url: https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl
+  sha256: 9422c40d1e350e4259f509fb2e608d6bc43c0136f79a00db1b49046029d0b3b7

--- a/org.gnome.DejaDup.yaml
+++ b/org.gnome.DejaDup.yaml
@@ -50,6 +50,7 @@ modules:
 
 - duplicity.yaml
 - fasteners.yaml
+- pexpect.yaml
 - rclone.yaml
 - restic.yaml
 
@@ -60,4 +61,4 @@ modules:
   sources:
   - type: git
     url: https://gitlab.gnome.org/World/deja-dup.git
-    commit: 04266b2fff9d6cceb392a1311c6929508c5e05ce
+    commit: 333ef94fe50cc4801405a4c18fbb8519ab921ab4

--- a/pexpect.yaml
+++ b/pexpect.yaml
@@ -1,0 +1,18 @@
+# -*- Mode: YAML; indent-tabs-mode: nil; tab-width: 2 -*-
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Michael Terry
+
+# Generated with flatpak-pip-generator --yaml --runtime org.gnome.Sdk//master --output pexpect pexpect
+name: python3-pexpect
+buildsystem: simple
+build-commands:
+- pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+  --prefix=${FLATPAK_DEST} "pexpect" --no-build-isolation
+sources:
+- type: file
+  url: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
+  sha256: 7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523
+- type: file
+  url: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
+  sha256: 4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35

--- a/rclone.yaml
+++ b/rclone.yaml
@@ -11,9 +11,9 @@ build-commands:
 sources:
 - type: archive
   only-arches: [x86_64]
-  url: https://github.com/rclone/rclone/releases/download/v1.71.0/rclone-v1.71.0-linux-amd64.zip
-  sha256: 3ddbcfd535ef2e6eb00cd006831766537f1fef1c8baeed1ee4632e7bcc699e93
+  url: https://github.com/rclone/rclone/releases/download/v1.72.1/rclone-v1.72.1-linux-amd64.zip
+  sha256: b5c9b2fb6ada8a400c5fc5d48cd112dc1adea21a3b73b03857059374dd8a78d0
 - type: archive
   only-arches: [aarch64]
-  url: https://github.com/rclone/rclone/releases/download/v1.71.0/rclone-v1.71.0-linux-arm64.zip
-  sha256: b710ac2ded37261d2cc6ab046dcd644828944524cf1ee7c2b17dd746f0fd8684
+  url: https://github.com/rclone/rclone/releases/download/v1.72.1/rclone-v1.72.1-linux-arm64.zip
+  sha256: 66ce9c7fbdf6ba38991fa2ac193ed051bd6d04aeec693900c848154bf549484f

--- a/restic.yaml
+++ b/restic.yaml
@@ -12,9 +12,9 @@ build-commands:
 sources:
 - type: file
   only-arches: [x86_64]
-  url: https://github.com/restic/restic/releases/download/v0.18.1/restic_0.18.1_linux_amd64.bz2
-  sha256: 680838f19d67151adba227e1570cdd8af12c19cf1735783ed1ba928bc41f363d
+  url: https://github.com/restic/restic/releases/download/v0.17.3/restic_0.17.3_linux_amd64.bz2
+  sha256: 5097faeda6aa13167aae6e36efdba636637f8741fed89bbf015678334632d4d3
 - type: file
   only-arches: [aarch64]
-  url: https://github.com/restic/restic/releases/download/v0.18.1/restic_0.18.1_linux_arm64.bz2
-  sha256: 87f53fddde38764095e9c058a3b31834052c37e5826d2acf34e18923c006bd45
+  url: https://github.com/restic/restic/releases/download/v0.17.3/restic_0.17.3_linux_arm64.bz2
+  sha256: db27b803534d301cef30577468cf61cb2e242165b8cd6d8cd6efd7001be2e557


### PR DESCRIPTION
- Upgrade duplicity and rclone to latest
- Downgrade restic to 0.17.3 to avoid a fuse bug in 0.18.1
- Bump deja-dup a few commits to get new translations and fix the version number